### PR TITLE
Added missing include for g++ compatibility, and updated pybind11 for Python 3.11 compatibility

### DIFF
--- a/source/smarties/Utils/MPIUtilities.h
+++ b/source/smarties/Utils/MPIUtilities.h
@@ -11,6 +11,7 @@
 
 #include <mpi.h>
 #include <omp.h>
+#include <stdexcept>
 
 namespace smarties
 {


### PR DESCRIPTION
I had to do these tiny fixes for the library to be compiled on my Debian system.